### PR TITLE
Add Server QuickConnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,14 @@ on disk.
 [client]
 downloadedServerContent = [{ name = "servermods", blackListRegex=["FilenameRegExp.*", "OtherFilenameRegexp.*"]}]
 ```
+
+### Auto-Connecting on Startup
+
+The client can be configured to auto-connect to a server after initial launch.
+
+_Note: The Vanilla launchers QuickPlay feature will take priority over this feature._
+
+```toml
+[client]
+quickPlayServer = "localhost:25565" # Your servers ip (The same as what you enter in game)
+```

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ sourceSets {
 
 neoForge {
     version = project.neoforgeVersion
+    accessTransformers.from("src/utilmod/resources/META-INF/accesstransformer.cfg")
 
     mods {
         spl {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 
-neoforgeVersion=21.0.110-beta
+neoforgeVersion=21.0.158
 
 neoForge.parchment.minecraftVersion=1.21
 neoForge.parchment.mappingsVersion=2024.07.07

--- a/src/main/java/net/forgecraft/serverpacklocator/ModAccessor.java
+++ b/src/main/java/net/forgecraft/serverpacklocator/ModAccessor.java
@@ -1,11 +1,11 @@
 package net.forgecraft.serverpacklocator;
 
+import java.util.UUID;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.UUID;
-import java.util.function.Predicate;
 
 public class ModAccessor {
     private static final Logger LOG = LoggerFactory.getLogger(ModAccessor.class);
@@ -14,6 +14,7 @@ public class ModAccessor {
     @Nullable
     private static volatile Predicate<UUID> allowListStrategy;
     private static volatile boolean logIps = true;
+    private static Supplier<String> quickPlayServer = () -> null;
 
     public static void setStatusLine(final String statusLine) {
         ModAccessor.statusLine = statusLine;
@@ -42,5 +43,14 @@ public class ModAccessor {
 
     public static void setLogIps(boolean logIps) {
         ModAccessor.logIps = logIps;
+    }
+
+    public static void setQuickPlayServer(Supplier<String> quickPlayServer) {
+        ModAccessor.quickPlayServer = quickPlayServer;
+    }
+
+    @Nullable
+    public static String getQuickPlayServer() {
+        return quickPlayServer.get();
     }
 }

--- a/src/main/java/net/forgecraft/serverpacklocator/client/ClientConfig.java
+++ b/src/main/java/net/forgecraft/serverpacklocator/client/ClientConfig.java
@@ -51,7 +51,6 @@ public class ClientConfig implements SecurityConfigHolder {
         @SpecNotNull
         private List<DownloadedServerContent> downloadedServerContent = new ArrayList<>();
 
-        @SpecNotNull
         private String quickPlayServer;
 
         public String getRemoteServer() {

--- a/src/main/java/net/forgecraft/serverpacklocator/client/ClientConfig.java
+++ b/src/main/java/net/forgecraft/serverpacklocator/client/ClientConfig.java
@@ -1,13 +1,11 @@
 package net.forgecraft.serverpacklocator.client;
 
-import com.electronwill.nightconfig.core.conversion.SpecIntInRange;
 import com.electronwill.nightconfig.core.conversion.SpecNotNull;
+import java.util.ArrayList;
+import java.util.List;
 import net.forgecraft.serverpacklocator.secure.SecurityConfig;
 import net.forgecraft.serverpacklocator.secure.SecurityConfigHolder;
 import net.forgecraft.serverpacklocator.utils.ObjectUtils;
-
-import java.util.ArrayList;
-import java.util.List;
 
 public class ClientConfig implements SecurityConfigHolder {
 
@@ -17,6 +15,7 @@ public class ClientConfig implements SecurityConfigHolder {
                 new Client(),
                 c -> {
                     c.remoteServer = "http://localhost:8080/";
+                    c.quickPlayServer = "";
                 }
         );
 
@@ -52,12 +51,19 @@ public class ClientConfig implements SecurityConfigHolder {
         @SpecNotNull
         private List<DownloadedServerContent> downloadedServerContent = new ArrayList<>();
 
+        @SpecNotNull
+        private String quickPlayServer;
+
         public String getRemoteServer() {
             return remoteServer;
         }
 
         public List<DownloadedServerContent> getDownloadedServerContent() {
             return downloadedServerContent;
+        }
+
+        public String getQuickPlayServer() {
+            return quickPlayServer;
         }
     }
 

--- a/src/main/java/net/forgecraft/serverpacklocator/client/ClientSidedPackHandler.java
+++ b/src/main/java/net/forgecraft/serverpacklocator/client/ClientSidedPackHandler.java
@@ -1,8 +1,5 @@
 package net.forgecraft.serverpacklocator.client;
 
-import net.forgecraft.serverpacklocator.ConfigException;
-import net.forgecraft.serverpacklocator.SidedPackHandler;
-
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -10,6 +7,9 @@ import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.function.Supplier;
+import net.forgecraft.serverpacklocator.ConfigException;
+import net.forgecraft.serverpacklocator.ModAccessor;
+import net.forgecraft.serverpacklocator.SidedPackHandler;
 
 public class ClientSidedPackHandler extends SidedPackHandler<ClientConfig> {
 
@@ -34,6 +34,8 @@ public class ClientSidedPackHandler extends SidedPackHandler<ClientConfig> {
                 this,
                 securityManager
         );
+
+        ModAccessor.setQuickPlayServer(() -> getConfig().getClient().getQuickPlayServer());
     }
 
     @Override

--- a/src/utilmod/java/net/forgecraft/serverpackutility/mixin/client/MinecraftMixin.java
+++ b/src/utilmod/java/net/forgecraft/serverpackutility/mixin/client/MinecraftMixin.java
@@ -21,8 +21,8 @@ public abstract class MinecraftMixin {
             cancellable = true
     )
     private void inject(@Nullable Minecraft.GameLoadCookie cookie, CallbackInfo ci) {
-        // quit out if cookie is missing or user requested quick play via vanilla client (launch args)
-        if (cookie == null || cookie.quickPlayData().isEnabled())
+        // quit out if user requested quick play via vanilla client (launch args)
+        if (cookie != null && cookie.quickPlayData().isEnabled())
             return;
 
         // parse server address

--- a/src/utilmod/java/net/forgecraft/serverpackutility/mixin/client/MinecraftMixin.java
+++ b/src/utilmod/java/net/forgecraft/serverpackutility/mixin/client/MinecraftMixin.java
@@ -1,0 +1,48 @@
+package net.forgecraft.serverpackutility.mixin.client;
+
+import net.forgecraft.serverpacklocator.ModAccessor;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.ConnectScreen;
+import net.minecraft.client.gui.screens.TitleScreen;
+import net.minecraft.client.gui.screens.multiplayer.JoinMultiplayerScreen;
+import net.minecraft.client.multiplayer.ServerData;
+import net.minecraft.client.multiplayer.resolver.ServerAddress;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Minecraft.class)
+public abstract class MinecraftMixin {
+    @Inject(
+            method = "lambda$buildInitialScreens$9",
+            at = @At("HEAD"),
+            cancellable = true
+    )
+    private void inject(@Nullable Minecraft.GameLoadCookie cookie, CallbackInfo ci) {
+        // quit out if cookie is missing or user requested quick play via vanilla client (launch args)
+        if (cookie == null || cookie.quickPlayData().isEnabled())
+            return;
+
+        // parse server address
+        var serverAddress = ServerAddress.parseString(ModAccessor.getQuickPlayServer());
+
+        // quit out if invalid server address passed
+        if (serverAddress.getHost().equals("server.invalid"))
+            return;
+
+        // connect to server
+        ConnectScreen.startConnecting(
+                new JoinMultiplayerScreen(new TitleScreen()),
+                (Minecraft) (Object) this,
+                serverAddress,
+                new ServerData("ServerPackLocator - QuickPlay Server", serverAddress.toString(), ServerData.Type.OTHER),
+                true,
+                null
+        );
+
+        // cancel vanilla code
+        ci.cancel();
+    }
+}

--- a/src/utilmod/resources/META-INF/accesstransformer.cfg
+++ b/src/utilmod/resources/META-INF/accesstransformer.cfg
@@ -1,0 +1,1 @@
+public net.minecraft.client.Minecraft$GameLoadCookie

--- a/src/utilmod/resources/META-INF/neoforge.mods.toml
+++ b/src/utilmod/resources/META-INF/neoforge.mods.toml
@@ -14,3 +14,5 @@ This mod is distributed as part of the ServerPackLocator to allow interaction wi
 '''
 [[mixins]]
 config="utilitymod.mixin.json"
+[[accessTransformers]]
+file="META-INF/accesstransformer.cfg"

--- a/src/utilmod/resources/utilitymod.mixin.json
+++ b/src/utilmod/resources/utilitymod.mixin.json
@@ -6,7 +6,9 @@
   "mixins": [
     "BrandingControlMixin"
   ],
-  "client": [],
+  "client": [
+    "client.MinecraftMixin"
+  ],
   "server": [],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
This PR adds a new config option to client configs, allowing users to auto connect to a server after initial game launch.
System will be ignored if user specifies an empty string or invalid ip.
<sub>Example config: `client = {quickPlayServer = "<server ip>"}`</sub>

The vanilla quick play system takes priority over this config, meaning that if a user uses the vanilla launcher to launch via quick play, the config option will be ignored and client will be connected to the vanilla quick play option instead.

NeoForge version has been bumped to latest, this was mainly to test auto connecting to the forgecraft server.
<sub>mods required newer neo version than was currently being setup.</sub>