### PR TITLE
Add missing manifest attributes to the utilmod jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,17 @@ configurations {
 def jarUtilMod = tasks.register(sourceSets.utilmod.jarTaskName, Jar) {
     archiveClassifier = "utilmod"
     from(sourceSets.utilmod.output)
+    manifest {
+        attributes(
+                'Specification-Title': project.name,
+                'Specification-Vendor': 'CPW',
+                'Specification-Version': project.version,
+                'Implementation-Title': project.name,
+                'Implementation-Version': project.version,
+                'Implementation-Vendor': 'CPW',
+                'Automatic-Module-Name': 'serverpacklocator',
+        )
+    }
 }
 
 def copyUtilMod = tasks.register("copyUtilMod", Copy) {


### PR DESCRIPTION
This PR fixes SPL not including a manifest with the recommended attributes, some of which are required for the utilities mod version to be detected properly by NeoForge

<table>
<tr>
<th>Broken version number</th>
<th>Fixed version number</th>
</tr>
<tr>
<td><img width="854" height="480" alt="Screenshot of original broken version number" src="https://github.com/user-attachments/assets/2fb02bc2-8cec-40c7-93e1-c295c2aff696"/></td>
<td><img width="854" height="480" alt="Screenshot of new version corrected version number" src="https://github.com/user-attachments/assets/822dcb59-e963-40ae-8bb5-d213e760b1ae"/></td>
</tr>
</table>